### PR TITLE
Add CLI queue subcommand test

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,6 +8,7 @@ pub fn build_cli() -> Command {
         .version("1.0.0")
         .author("Ibrahim Mohamed")
         .about("Advanced video downloader for various content sources")
+        .subcommand_negates_reqs(true)
         .subcommand(
             Command::new("download")
                 .about("Download a video or audio")

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -156,3 +156,23 @@ fn test_cli_invalid_arguments() {
     ]);
     assert!(result.is_err());
 }
+
+#[test]
+fn test_cli_queue_list_subcommand() {
+    let app = build_cli();
+
+    // Parse the queue list subcommand
+    let result = app.clone().try_get_matches_from(vec!["rustloader", "queue", "list"]);
+    assert!(result.is_ok());
+    let matches = result.unwrap();
+
+    match matches.subcommand() {
+        Some(("queue", queue_matches)) => {
+            match queue_matches.subcommand() {
+                Some(("list", _)) => {},
+                other => panic!("Expected 'list' subcommand, got {:?}", other),
+            }
+        }
+        other => panic!("Expected 'queue' subcommand, got {:?}", other),
+    }
+}


### PR DESCRIPTION
## Summary
- ensure queue subcommand doesn't require URL
- test queue list subcommand parsing

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68403de7ee38832dab732458b872a169